### PR TITLE
Republish github pages and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 release_notes/
+.idea/
+.DS_Store


### PR DESCRIPTION
This commit is needed to trigger GitHub to republish the pages following the master branch being renamed to main. This also updates the gitignore file in the project.

![image](https://user-images.githubusercontent.com/106100509/187510286-cd015f9f-d017-4196-8f2c-9890f65bbc24.png)
